### PR TITLE
Upload file fix

### DIFF
--- a/bellatrix.web/src/main/java/solutions/bellatrix/web/components/FileInput.java
+++ b/bellatrix.web/src/main/java/solutions/bellatrix/web/components/FileInput.java
@@ -28,7 +28,7 @@ public class FileInput extends WebComponent implements ComponentRequired, Compon
     }
 
     public void upload(String file) {
-        defaultSetText(UPLOADING, UPLOADED, file);
+        defaultUpload(UPLOADING, UPLOADED, file);
     }
 
     @Override

--- a/bellatrix.web/src/main/java/solutions/bellatrix/web/components/WebComponent.java
+++ b/bellatrix.web/src/main/java/solutions/bellatrix/web/components/WebComponent.java
@@ -1004,6 +1004,14 @@ public class WebComponent extends LayoutComponentValidationsBuilder implements C
         valueSet.broadcast(new ComponentActionEventArgs(this, value));
     }
 
+    protected void defaultUpload(EventListener<ComponentActionEventArgs> settingValue, EventListener<ComponentActionEventArgs> valueSet, String value) {
+        settingValue.broadcast(new ComponentActionEventArgs(this, value));
+
+        getWrappedElement().sendKeys(value);
+
+        valueSet.broadcast(new ComponentActionEventArgs(this, value));
+    }
+
     private WebElement findNativeElement() {
         if (parentWrappedElement == null) {
             return wrappedDriver.findElements(findStrategy.convert()).get(elementIndex);


### PR DESCRIPTION
Fix upload file not working in some occasions because .clear() is throwing an exception that the element is not interactable because of it being read-only