### PR TITLE
Instance and Singleton Factory Update

### DIFF
--- a/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
+++ b/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
@@ -1,0 +1,116 @@
+package solutions.bellatrix.core.utilities;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+
+public abstract class ObjectFactory {
+    protected static <T> T newInstance(Class<T> clazz, Object... initargs) throws InvocationTargetException, InstantiationException, IllegalAccessException, ConstructorNotFoundException {
+        var args = new Ref<Object[]>(initargs);
+
+        Constructor<T> suitableConstructor = getSuitableConstructor(clazz, args);
+
+        return (T)suitableConstructor.newInstance(args.value);
+    }
+
+    private static <T> Constructor<T> getSuitableConstructor(Class<T> clazz, Ref<Object[]> argumentsReference) throws ConstructorNotFoundException {
+        var argumentTypes = getArgumentTypes(argumentsReference.value);
+
+        try {
+            var match = findMatch(clazz, argumentTypes);
+            if (match.isVarArgs() && match.getParameterCount() != argumentsReference.value.length) {
+                argumentsReference.value = Arrays.copyOf(argumentsReference.value, argumentsReference.value.length + 1);
+                argumentsReference.value[argumentsReference.value.length - 1] = null;
+            }
+            return (Constructor<T>)match;
+        } catch (NoSuchMethodException e) {
+            var types = new StringBuilder();
+            for (var type : argumentTypes) {
+                types.append(type.getName() + System.lineSeparator());
+            }
+
+            throw new ConstructorNotFoundException(("""
+                No constructor with the specified parameters was found.
+                Given argument count: %d
+                Given argument types: %s
+                %s
+                """).formatted(argumentTypes.length, types.toString(), e)
+            );
+        }
+    }
+
+    private static Class[] getArgumentTypes(Object... initargs) {
+        if (initargs == null || initargs.length == 0) return null;
+
+        Class[] argumentTypes = new Class[initargs.length];
+        for (var i = 0; i < initargs.length; i++) {
+            argumentTypes[i] = initargs[i].getClass();
+        }
+
+        return argumentTypes;
+    }
+
+    private static <T> Constructor<T> findMatch(Class clazz, Class[] argumentTypes) throws NoSuchMethodException {
+        var constructors = clazz.getDeclaredConstructors();
+
+        for (var constructor : constructors) {
+            var parameters = constructor.getParameters();
+
+            if (parametersMatch(parameters, argumentTypes)) {
+                return constructor;
+            }
+        }
+
+        throw new NoSuchMethodException("No matching constructor found for the provided argument types.");
+    }
+
+    private static boolean parametersMatch(Parameter[] parameters, Class[] argumentTypes) {
+        if (bothNullOrEmpty(parameters, argumentTypes)) {
+            return true;
+        } else if (lengthMismatch(parameters, argumentTypes)) {
+            return false;
+        }
+
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameters[i].isVarArgs() && argumentTypes.length == i) {
+                return true;
+            }
+
+            if (!argumentTypes[i].equals(parameters[i].getType())) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean lengthMismatch(Parameter[] parameters, Class[] argumentTypes) {
+        return (argumentTypes == null) || (parameters.length < argumentTypes.length);
+    }
+
+    private static boolean bothNullOrEmpty(Parameter[] parameters, Class[] argumentTypes) {
+        return (argumentTypes == null || argumentTypes.length == 0) && (parameters == null || parameters.length == 0);
+    }
+
+    public static class ConstructorNotFoundException extends Exception {
+        public ConstructorNotFoundException() {
+        }
+
+        public ConstructorNotFoundException(String message) {
+            super(message);
+        }
+
+        public ConstructorNotFoundException(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        public ConstructorNotFoundException(Throwable cause) {
+            super(cause);
+        }
+
+        public ConstructorNotFoundException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+            super(message, cause, enableSuppression, writableStackTrace);
+        }
+    }
+}

--- a/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
+++ b/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
@@ -23,16 +23,13 @@ public abstract class ObjectFactory {
         Constructor<T> suitableConstructor = getSuitableConstructor(clazz, args);
 
         if (suitableConstructor.isVarArgs() && args.length < suitableConstructor.getParameterCount()) {
-            return (T)suitableConstructor.newInstance(addNullVarArgs(args));
+            return (T)suitableConstructor.newInstance(addNullVarArgsTo(args));
         } else
             return (T)suitableConstructor.newInstance(args);
     }
 
-    private static Object[] addNullVarArgs(Object... args) {
-        var newArgs = Arrays.copyOf(args, args.length + 1);
-        newArgs[newArgs.length - 1] = null;
-
-        return newArgs;
+    private static Object[] addNullVarArgsTo(Object... args) {
+        return Arrays.copyOf(args, args.length + 1);
     }
 
     private static <T> Constructor<T> getSuitableConstructor(Class<T> clazz, Object[] arguments) throws ConstructorNotFoundException {

--- a/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
+++ b/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
@@ -44,12 +44,7 @@ public abstract class ObjectFactory {
                 types.append(type.getName() + System.lineSeparator());
             }
 
-            throw new ConstructorNotFoundException(("""
-                    No constructor with the specified parameters was found.
-                    Given argument count: %d
-                    Given argument types: %s
-                    """).formatted(argumentTypes.length, types.toString())
-            );
+            throw new ConstructorNotFoundException(argumentTypes.length, types.toString());
         }
     }
 
@@ -107,6 +102,13 @@ public abstract class ObjectFactory {
     }
 
     public static class ConstructorNotFoundException extends Exception {
+        public ConstructorNotFoundException(int numberOfTypes, String types) {
+            super(("""
+                    No constructor with the specified parameters was found.
+                    Given argument count: %d
+                    Given argument types: %s
+                    """).formatted(numberOfTypes, types));
+        }
         public ConstructorNotFoundException() {
         }
 

--- a/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
+++ b/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2024 Automate The Planet Ltd.
+ * Author: Miriyam Kyoseva
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package solutions.bellatrix.core.utilities;
 
 import java.lang.reflect.Constructor;
@@ -31,11 +45,10 @@ public abstract class ObjectFactory {
             }
 
             throw new ConstructorNotFoundException(("""
-                No constructor with the specified parameters was found.
-                Given argument count: %d
-                Given argument types: %s
-                %s
-                """).formatted(argumentTypes.length, types.toString(), e)
+                    No constructor with the specified parameters was found.
+                    Given argument count: %d
+                    Given argument types: %s
+                    """).formatted(argumentTypes.length, types.toString())
             );
         }
     }
@@ -77,7 +90,7 @@ public abstract class ObjectFactory {
                 return true;
             }
 
-            if (!argumentTypes[i].equals(parameters[i].getType())) {
+            if (argumentTypes.length - 1 < i || !argumentTypes[i].equals(parameters[i].getType())) {
                 return false;
             }
         }

--- a/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/SingletonFactory.java
+++ b/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/SingletonFactory.java
@@ -38,18 +38,21 @@ public class SingletonFactory extends ObjectFactory {
     private static <T> T tryGetInstance(Class<T> classOf, Object... initargs) {
         try {
             return newInstance(classOf, initargs);
-        } catch (InvocationTargetException|InstantiationException|IllegalAccessException|ConstructorNotFoundException e) {
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException |
+                 ConstructorNotFoundException e) {
             Log.error("Failed to create instance of the class %s.\nException was:\n%s".formatted(classOf.getName(), e));
             return null;
         }
     }
 
     public static <T> void register(T instance) {
-        mapHolder.get().put(instance.getClass(), instance);
+        if (instance != null)
+            mapHolder.get().put(instance.getClass(), instance);
     }
 
     public static <T> void register(Class<?> classKey, T instance) {
-        mapHolder.get().put(classKey, instance);
+        if (instance != null)
+            mapHolder.get().put(classKey, instance);
     }
 
     public static void clear() {

--- a/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/SingletonFactory.java
+++ b/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/SingletonFactory.java
@@ -13,9 +13,9 @@
 
 package solutions.bellatrix.core.utilities;
 
-import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,20 +23,23 @@ import java.util.Map;
 // Can be used inside App design pattern.
 @SuppressWarnings("unchecked")
 @UtilityClass
-public class SingletonFactory {
+public class SingletonFactory extends ObjectFactory {
     private static final ThreadLocal<Map<Class<?>, Object>> mapHolder = ThreadLocal.withInitial(HashMap::new);
 
-    @SneakyThrows
     public static <T> T getInstance(Class<T> classOf, Object... initargs) {
-        try {
-            if (!mapHolder.get().containsKey(classOf)) {
-                T obj = (T)classOf.getConstructors()[0].newInstance(initargs);
-                register(obj);
-            }
+        if (!mapHolder.get().containsKey(classOf)) {
+            T obj = tryGetInstance(classOf, initargs);
+            register(obj);
+        }
 
-            return (T)mapHolder.get().get(classOf);
-        } catch (Exception e) {
-            Log.error("Failed to create instance of the object. Exception was: " + e);
+        return (T)mapHolder.get().get(classOf);
+    }
+
+    private static <T> T tryGetInstance(Class<T> classOf, Object... initargs) {
+        try {
+            return newInstance(classOf, initargs);
+        } catch (InvocationTargetException|InstantiationException|IllegalAccessException|ConstructorNotFoundException e) {
+            Log.error("Failed to create instance of the class %s.\nException was:\n%s".formatted(classOf.getName(), e));
             return null;
         }
     }

--- a/framework-tests/bellatrix.core.tests/pom.xml
+++ b/framework-tests/bellatrix.core.tests/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>bellatrix</artifactId>
+        <groupId>solutions.bellatrix</groupId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>bellatrix.core.tests</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>solutions.bellatrix</groupId>
+            <artifactId>bellatrix.core</artifactId>
+            <version>1.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
@@ -1,7 +1,6 @@
 package factory;
 
 import factory.data.Employee;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import solutions.bellatrix.core.plugins.junit.BaseTest;
@@ -9,27 +8,27 @@ import solutions.bellatrix.core.utilities.InstanceFactory;
 
 public class InstanceFactoryTests extends BaseTest {
     @Test
-    public void testNoArgsConstructor() {
+    public void objectReturned_When_UsedNoArgsConstructor() {
         Assertions.assertNotNull(InstanceFactory.create(Employee.class));
     }
 
     @Test
-    public void testAllArgsConstructor() {
+    public void objectReturned_When_UsedAllArgsConstructor() {
         Assertions.assertNotNull(InstanceFactory.create(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com"));
     }
 
     @Test
-    public void testAllArgsConstructorWithVarArgs() {
+    public void objectReturned_When_UsedAllArgsWithVarArgsConstructor() {
         Assertions.assertNotNull(InstanceFactory.create(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com", new Object[] { new Employee("Jane", "Doe") }));
     }
 
     @Test
-    public void testCustomArgsConstructor() {
+    public void objectReturned_When_UsedCustomArgsConstructor() {
         Assertions.assertNotNull(InstanceFactory.create(Employee.class, "John", "Doe"));
     }
 
     @Test
-    public void testUsingNonExistentConstructor() {
+    public void objectNotReturned_When_UsedNonExistentConstructor() {
         Assertions.assertNull(InstanceFactory.create(Employee.class, "John Doe"));
     }
 }

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
@@ -1,6 +1,7 @@
 package factory;
 
 import factory.data.Employee;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import solutions.bellatrix.core.plugins.junit.BaseTest;
@@ -25,5 +26,10 @@ public class InstanceFactoryTests extends BaseTest {
     @Test
     public void testCustomArgsConstructor() {
         Assertions.assertNotNull(InstanceFactory.create(Employee.class, "John", "Doe"));
+    }
+
+    @Test
+    public void testUsingNonExistentConstructor() {
+        Assertions.assertNull(InstanceFactory.create(Employee.class, "John Doe"));
     }
 }

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
@@ -1,0 +1,29 @@
+package factory;
+
+import factory.data.Employee;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import solutions.bellatrix.core.plugins.junit.BaseTest;
+import solutions.bellatrix.core.utilities.InstanceFactory;
+
+public class InstanceFactoryTests extends BaseTest {
+    @Test
+    public void testNoArgsConstructor() {
+        Assertions.assertNotNull(InstanceFactory.create(Employee.class));
+    }
+
+    @Test
+    public void testAllArgsConstructor() {
+        Assertions.assertNotNull(InstanceFactory.create(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com"));
+    }
+
+    @Test
+    public void testAllArgsConstructorWithVarArgs() {
+        Assertions.assertNotNull(InstanceFactory.create(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com", new Object[] { new Employee("Jane", "Doe") }));
+    }
+
+    @Test
+    public void testCustomArgsConstructor() {
+        Assertions.assertNotNull(InstanceFactory.create(Employee.class, "John", "Doe"));
+    }
+}

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
@@ -19,6 +19,16 @@ public class SingletonFactoryTests extends BaseTest {
     }
 
     @Test
+    public void noEntriesRemaining_When_SingletonFactoryClear() {
+        var johnDoe = new Employee("John", "Doe");
+        SingletonFactory.register(johnDoe);
+
+        SingletonFactory.clear();
+
+        Assertions.assertNotEquals(johnDoe, SingletonFactory.getInstance(Employee.class));
+    }
+
+    @Test
     public void objectReturned_When_UsedNoArgsConstructor() {
         Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class));
     }

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
@@ -1,6 +1,7 @@
 package factory;
 
 import factory.data.Employee;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import solutions.bellatrix.core.plugins.junit.BaseTest;
@@ -29,11 +30,21 @@ public class SingletonFactoryTests extends BaseTest {
 
     @Test
     public void testAllArgsConstructorWithVarArgs() {
-        Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com", new Object[] { new Employee("Jane", "Doe") }));
+        Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com", new Object[]{new Employee("Jane", "Doe")}));
     }
 
     @Test
     public void testCustomArgsConstructor() {
         Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "John", "Doe"));
+    }
+
+    @Test
+    public void testUsingNonExistentConstructor() {
+        Assertions.assertNull(SingletonFactory.getInstance(Employee.class, "John Doe"));
+    }
+
+    @AfterEach
+    public void clearSingletonFactoryMap() {
+        SingletonFactory.clear();
     }
 }

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
@@ -1,0 +1,39 @@
+package factory;
+
+import factory.data.Employee;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import solutions.bellatrix.core.plugins.junit.BaseTest;
+import solutions.bellatrix.core.utilities.SingletonFactory;
+
+public class SingletonFactoryTests extends BaseTest {
+    @Test
+    public void testExistingObjectReturnedWhenFound() {
+        var johnDoe = new Employee("John", "Doe");
+        SingletonFactory.register(johnDoe);
+
+        var employee = SingletonFactory.getInstance(Employee.class, "Jane", "Doe");
+
+        Assertions.assertEquals(johnDoe.firstName, employee.firstName);
+    }
+
+    @Test
+    public void testNoArgsConstructor() {
+        Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class));
+    }
+
+    @Test
+    public void testAllArgsConstructor() {
+        Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com"));
+    }
+
+    @Test
+    public void testAllArgsConstructorWithVarArgs() {
+        Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com", new Object[] { new Employee("Jane", "Doe") }));
+    }
+
+    @Test
+    public void testCustomArgsConstructor() {
+        Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "John", "Doe"));
+    }
+}

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/SingletonFactoryTests.java
@@ -9,7 +9,7 @@ import solutions.bellatrix.core.utilities.SingletonFactory;
 
 public class SingletonFactoryTests extends BaseTest {
     @Test
-    public void testExistingObjectReturnedWhenFound() {
+    public void existingObjectReturned_When_GetInstance() {
         var johnDoe = new Employee("John", "Doe");
         SingletonFactory.register(johnDoe);
 
@@ -19,27 +19,27 @@ public class SingletonFactoryTests extends BaseTest {
     }
 
     @Test
-    public void testNoArgsConstructor() {
+    public void objectReturned_When_UsedNoArgsConstructor() {
         Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class));
     }
 
     @Test
-    public void testAllArgsConstructor() {
+    public void objectReturned_When_UsedAllArgsConstructor() {
         Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com"));
     }
 
     @Test
-    public void testAllArgsConstructorWithVarArgs() {
+    public void objectReturned_When_UsedAllArgsWithVarArgsConstructor() {
         Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "0", "John", "Doe", "jdoe@corp.com", "john.doe@gmail.com", new Object[]{new Employee("Jane", "Doe")}));
     }
 
     @Test
-    public void testCustomArgsConstructor() {
+    public void objectReturned_When_UsedCustomArgsConstructor() {
         Assertions.assertNotNull(SingletonFactory.getInstance(Employee.class, "John", "Doe"));
     }
 
     @Test
-    public void testUsingNonExistentConstructor() {
+    public void objectNotReturned_When_UsedNonExistentConstructor() {
         Assertions.assertNull(SingletonFactory.getInstance(Employee.class, "John Doe"));
     }
 

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/data/Employee.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/data/Employee.java
@@ -1,0 +1,31 @@
+package factory.data;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class Employee {
+    public Employee() {
+    }
+
+    public Employee(String order, String firstName, String lastName, String businessEmail, String personalEmail, Object... additionalData) {
+        this.order = order;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.businessEmail = businessEmail;
+        this.personalEmail = personalEmail;
+        this.additionalData = additionalData;
+    }
+
+    public Employee(String firstName, String lastName) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public String order;
+    public String firstName;
+    public String lastName;
+    public String businessEmail;
+    public String personalEmail;
+    public Object[] additionalData;
+}

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/data/Employee.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/data/Employee.java
@@ -1,13 +1,11 @@
 package factory.data;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter @Setter
+@Getter @Setter @NoArgsConstructor
 public class Employee {
-    public Employee() {
-    }
-
     public Employee(String order, String firstName, String lastName, String businessEmail, String personalEmail, Object... additionalData) {
         this.order = order;
         this.firstName = firstName;

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>bellatrix.ios</module>
         <module>bellatrix.api</module>
         <!-- Framework Tests -->
+        <module>framework-tests/bellatrix.core.tests</module>
         <module>framework-tests/bellatrix.web.tests</module>
         <module>framework-tests/bellatrix.desktop.tests</module>
         <module>framework-tests/bellatrix.android.tests</module>


### PR DESCRIPTION
+ Custom logic for finding constructors based on the arguments provided
+ Tests for both factories

No more failures to create an instance due to the intended (usually the default) constructor not being the first!
- no more rearranging of the positions of lombok annotations "AllArgsConstructor" with "NoArgsConstructor"
- no more rearranging of constructors so that the intended constructor could be the first
+ robust finding of the intended constructor based on the given arguments
+ handling of varargs in constructors (if not specified in the given arguments)