### PR TITLE
ObjectFactory Fix for No Args Constructor

### DIFF
--- a/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
+++ b/bellatrix.core/src/main/java/solutions/bellatrix/core/utilities/ObjectFactory.java
@@ -37,8 +37,12 @@ public abstract class ObjectFactory {
         var argumentTypes = getArgumentTypes(arguments);
 
         try {
-            return (Constructor<T>)findConstructorMatch(clazz, argumentTypes);
+            return findConstructorMatch(clazz, argumentTypes);
         } catch (NoSuchMethodException e) {
+            if (argumentTypes == null || argumentTypes.length == 0) {
+                throw new ConstructorNotFoundException();
+            }
+
             var types = new StringBuilder();
             for (var type : argumentTypes) {
                 types.append(type.getName() + System.lineSeparator());
@@ -73,7 +77,7 @@ public abstract class ObjectFactory {
             args[args.length - 1] = getVarArgsType(clazz, argumentTypes);
 
             return clazz.getDeclaredConstructor(args);
-        } catch (NoSuchMethodException ignored) {
+        } catch (NoSuchMethodException|NullPointerException ignored) {
         }
 
         throw new NoSuchMethodException("No matching constructor found for the provided argument types.");
@@ -113,7 +117,9 @@ public abstract class ObjectFactory {
                     Given argument types:\n%s
                     """).formatted(numberOfTypes, types));
         }
+
         public ConstructorNotFoundException() {
+            super("No default constructor was found." + System.lineSeparator());
         }
 
         public ConstructorNotFoundException(String message) {

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/InstanceFactoryTests.java
@@ -1,10 +1,12 @@
 package factory;
 
+import factory.data.Boss;
 import factory.data.Employee;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import solutions.bellatrix.core.plugins.junit.BaseTest;
 import solutions.bellatrix.core.utilities.InstanceFactory;
+import solutions.bellatrix.core.utilities.ObjectFactory;
 
 public class InstanceFactoryTests extends BaseTest {
     @Test
@@ -28,7 +30,12 @@ public class InstanceFactoryTests extends BaseTest {
     }
 
     @Test
-    public void objectNotReturned_When_UsedNonExistentConstructor() {
+    public void returnedNull_When_TriedUsingNonExistentConstructor() {
         Assertions.assertNull(InstanceFactory.create(Employee.class, "John Doe"));
+    }
+
+    @Test
+    public void returnedNull_When_TriedUsingNonExistentNoArgsConstructor() {
+        Assertions.assertNull(InstanceFactory.create(Boss.class));
     }
 }

--- a/framework-tests/bellatrix.core.tests/src/test/java/factory/data/Boss.java
+++ b/framework-tests/bellatrix.core.tests/src/test/java/factory/data/Boss.java
@@ -1,0 +1,23 @@
+package factory.data;
+
+public class Boss {
+    public Boss(String firstName, String lastName, String businessEmail) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.businessEmail = businessEmail;
+    }
+
+    public Boss(String firstName, String lastName, String businessEmail, String personalEmail, Object[] additionalData) {
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.businessEmail = businessEmail;
+        this.personalEmail = personalEmail;
+        this.additionalData = additionalData;
+    }
+
+    public String firstName;
+    public String lastName;
+    public String businessEmail;
+    public String personalEmail;
+    public Object[] additionalData;
+}


### PR DESCRIPTION
Now it throws the right error `ConstructorNotFoundException` instead of `NullPointerException` when trying to call non args constructor while such is not defined