### PR TITLE
Shadow Dom GetHtml and Retry Logic Update

### DIFF
--- a/bellatrix.web/src/main/java/solutions/bellatrix/web/components/WebComponent.java
+++ b/bellatrix.web/src/main/java/solutions/bellatrix/web/components/WebComponent.java
@@ -1081,17 +1081,15 @@ public class WebComponent extends LayoutComponentValidationsBuilder implements C
     }
 
     protected String defaultGetInnerHtmlAttribute() {
-        if (!this.inShadowContext()) {
+        if (this instanceof ShadowRoot) {
+            return ShadowDomService.getShadowHtml(this, true);
+        } else if (this.inShadowContext()) {
+            return ShadowDomService.getShadowHtml(this, false);
+        } else {
             try {
                 return Optional.ofNullable(getAttribute("innerHTML")).orElse("");
             } catch (StaleElementReferenceException e) {
                 return Optional.ofNullable(findElement().getAttribute("innerHTML")).orElse("");
-            }
-        } else {
-            if (this instanceof ShadowRoot) {
-                return ShadowDomService.getShadowHtml(this, true);
-            } else {
-                return ShadowDomService.getShadowHtml(this, false);
             }
         }
     }

--- a/bellatrix.web/src/main/java/solutions/bellatrix/web/components/shadowdom/ShadowDomService.java
+++ b/bellatrix.web/src/main/java/solutions/bellatrix/web/components/shadowdom/ShadowDomService.java
@@ -15,6 +15,7 @@ package solutions.bellatrix.web.components.shadowdom;
 
 import lombok.experimental.UtilityClass;
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import solutions.bellatrix.core.configuration.ConfigurationService;
 import solutions.bellatrix.core.utilities.InstanceFactory;
 import solutions.bellatrix.core.utilities.Ref;
@@ -261,7 +262,7 @@ public class ShadowDomService {
                 throw new RuntimeException(e);
             }
         } else {
-            throw new IllegalArgumentException("No element inside the shadow DOM was found with the findStrategy: " + findStrategy.toString());
+            throw new NoSuchElementException("No element inside the shadow DOM was found with the findStrategy: " + findStrategy.toString());
         }
     }
 

--- a/bellatrix.web/src/main/java/solutions/bellatrix/web/components/shadowdom/ShadowDomService.java
+++ b/bellatrix.web/src/main/java/solutions/bellatrix/web/components/shadowdom/ShadowDomService.java
@@ -253,7 +253,7 @@ public class ShadowDomService {
                 throw new RuntimeException(e);
             }
 
-            if (foundElements.size() == 0) throw new IllegalArgumentException();
+            if (foundElements.isEmpty()) throw new IllegalArgumentException();
 
         }, Duration.ofSeconds(ConfigurationService.get(WebSettings.class).getTimeoutSettings().getElementWaitTimeout()), Duration.ofSeconds(1), false)) {
             try {

--- a/bellatrix.web/src/main/java/solutions/bellatrix/web/components/shadowdom/ShadowDomService.java
+++ b/bellatrix.web/src/main/java/solutions/bellatrix/web/components/shadowdom/ShadowDomService.java
@@ -20,6 +20,7 @@ import solutions.bellatrix.core.utilities.InstanceFactory;
 import solutions.bellatrix.core.utilities.Ref;
 import solutions.bellatrix.core.utilities.Wait;
 import solutions.bellatrix.web.components.WebComponent;
+import solutions.bellatrix.web.components.contracts.Component;
 import solutions.bellatrix.web.configuration.WebSettings;
 import solutions.bellatrix.web.findstrategies.CssFindStrategy;
 import solutions.bellatrix.web.findstrategies.FindStrategy;
@@ -43,7 +44,16 @@ public class ShadowDomService {
     }
 
     public static <TComponent extends WebComponent, TFindStrategy extends FindStrategy> TComponent createFromShadowRoot(Class<TComponent> componentClass, ShadowRoot parentComponent, TFindStrategy findStrategy) {
-        return createAllFromShadowRoot(componentClass, parentComponent, findStrategy).get(0);
+        if (Wait.retry(() -> {
+            List<TComponent> foundElements = createAllFromShadowRoot(componentClass, parentComponent, findStrategy);
+
+            if (foundElements.size() == 0) throw new IllegalArgumentException();
+
+        }, Duration.ofSeconds(ConfigurationService.get(WebSettings.class).getTimeoutSettings().getElementWaitTimeout()), Duration.ofSeconds(1), false)) {
+            return createAllFromShadowRoot(componentClass, parentComponent, findStrategy).get(0);
+        } else {
+            throw new IllegalArgumentException("No elements inside the shadow DOM were found with the findStrategy: " + findStrategy.toString());
+        }
     }
 
     public static <TComponent extends WebComponent, TFindStrategy extends FindStrategy> List<TComponent> createAllFromShadowRoot(Class<TComponent> componentClass, ShadowRoot parentComponent, TFindStrategy findStrategy) {
@@ -69,7 +79,16 @@ public class ShadowDomService {
     }
 
     public static <TComponent extends WebComponent, TFindStrategy extends FindStrategy> TComponent createInShadowContext(Class<TComponent> componentClass, WebComponent parentComponent, TFindStrategy findStrategy) {
-        return createAllInShadowContext(componentClass, parentComponent, findStrategy).get(0);
+        if (Wait.retry(() -> {
+            List<TComponent> foundElements = createAllInShadowContext(componentClass, parentComponent, findStrategy);
+
+            if (foundElements.size() == 0) throw new IllegalArgumentException();
+
+        }, Duration.ofSeconds(ConfigurationService.get(WebSettings.class).getTimeoutSettings().getElementWaitTimeout()), Duration.ofSeconds(1), false)) {
+            return createAllInShadowContext(componentClass, parentComponent, findStrategy).get(0);
+        } else {
+            throw new IllegalArgumentException("No elements inside the shadow DOM were found with the findStrategy: " + findStrategy.toString());
+        }
     }
 
     public static <TComponent extends WebComponent, TFindStrategy extends FindStrategy> List<TComponent> createAllInShadowContext(Class<TComponent> componentClass, WebComponent parentComponent, TFindStrategy findStrategy) {
@@ -103,7 +122,7 @@ public class ShadowDomService {
                             shadowRoot.findElement(), locator, null).toArray(String[]::new);
         };
 
-        return getCss(js, locator);
+        return getCss(js);
     }
 
     private static String[] getRelativeCss(ShadowRoot shadowRoot, String locator, String parentLocator) {
@@ -113,30 +132,18 @@ public class ShadowDomService {
                             shadowRoot.findElement(), locator, parentLocator).toArray(String[]::new);
         };
 
-        return getCss(js, locator);
+        return getCss(js);
     }
 
-    private static String[] getCss(Callable<String[]> callable, String locator) {
-        if (Wait.retry(() -> {
-            String[] foundElements;
-            try {
-                foundElements = callable.call();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            if (foundElements == null || foundElements.length == 0) {
-                throw new IllegalArgumentException();
-            }
-        }, Duration.ofSeconds(ConfigurationService.get(WebSettings.class).getTimeoutSettings().getElementWaitTimeout()), Duration.ofSeconds(1), false)) {
-            try {
-                return callable.call();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            throw new IllegalArgumentException("No elements inside the shadow DOM were found with the locator: " + locator);
+    private static String[] getCss(Callable<String[]> callable) {
+        String[] foundElements;
+        try {
+            foundElements = callable.call();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
+
+        return foundElements;
     }
 
     private static <TComponent extends WebComponent> TComponent buildMissingShadowRootsAndCreate(Class<TComponent> clazz, ShadowRoot parentComponent, Ref<String> fullCss) {
@@ -206,7 +213,7 @@ public class ShadowDomService {
             }
 
             StringBuilder finalCss = new StringBuilder();
-            while(!findStrategies.isEmpty()) {
+            while (!findStrategies.isEmpty()) {
                 finalCss.append(findStrategies.pop());
             }
 
@@ -338,11 +345,11 @@ public class ShadowDomService {
                 }
                 
                 let startPoint = temporaryDiv;
-    
+                
                 if (relativeElementCss) {
                     startPoint = temporaryDiv.querySelector(relativeElementCss);
                 }
-    
+                
                 let elements;
                 if (locator.startsWith("/") || locator.startsWith("./") || locator.startsWith("(")) {
                   let result = document.evaluate(locator, startPoint, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
@@ -354,12 +361,12 @@ public class ShadowDomService {
                 } else {
                   elements = Array.from(startPoint.querySelectorAll(locator));
                 }
-    
+                
                 let finalLocators = [];
                 elements.forEach((el) => {
                   finalLocators.push(getAbsoluteCss(getAbsoluteXpath(el)));
                 });
-    
+                
                 return finalLocators;
             }""";
 
@@ -367,7 +374,7 @@ public class ShadowDomService {
             function (element, isShadowRoot) {
                 const child_combinator = " > ";
                 const node = "/";
-            
+                        
                 function clone(element, tag) {
                   let cloneElement;
                   if (element instanceof ShadowRoot && !tag) {
@@ -381,20 +388,20 @@ public class ShadowDomService {
                       cloneElement.appendChild(element.firstChild.cloneNode());
                     }
                   }
-            
+                        
                   if (element.shadowRoot) {
                     cloneElement.appendChild(clone(element.shadowRoot, "shadow-root"));
                   }
-            
+                        
                   if (element.children) {
                     for (const child of element.children) {
                       cloneElement.appendChild(clone(child, undefined));
                     }
                   }
-            
+                        
                   return cloneElement;
                 }
-            
+                        
                 let temporaryDiv = document.createElement("temporary-div");
                 if (element.shadowRoot) {
                       temporaryDiv.appendChild(clone(element.shadowRoot, undefined));
@@ -404,7 +411,7 @@ public class ShadowDomService {
                     temporaryDiv.appendChild(clone(element, "redundant-el"));
                     temporaryDiv = temporaryDiv.querySelector("redundant-el");
                 }
-            
+                        
                 return temporaryDiv.innerHTML;
             }
             """;

--- a/framework-tests/bellatrix.web.tests/src/test/java/controls/shadowdom/ShadowDomTests.java
+++ b/framework-tests/bellatrix.web.tests/src/test/java/controls/shadowdom/ShadowDomTests.java
@@ -107,5 +107,24 @@ public class ShadowDomTests extends WebTest {
         Assertions.assertEquals("edit", edit.getText());
     }
 
+    @Test
+    public void exceptionThrown_when_tryingToFindNonExistentElement() {
+        var shadowHost = app().create().byId(Div.class, "complexShadowHost");
+        var shadowRoot = shadowHost.getShadowRoot();
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> shadowRoot.createByXPath(Div.class, "//nonExistentElement"));
+    }
+
+    @Test
+    public void returnedEmptyList_when_tryingToFindNonExistentElements() {
+        var shadowHost = app().create().byId(Div.class, "complexShadowHost");
+        var shadowRoot = shadowHost.getShadowRoot();
+
+        Assertions.assertAll(
+                () -> Assertions.assertDoesNotThrow(() -> shadowRoot.createAllByXPath(Div.class, "//nonExistentElement")),
+                () -> Assertions.assertTrue(shadowRoot.createAllByXPath(Div.class, "//nonExistentElement").isEmpty())
+        );
+    }
+
     // TODO: Test Relative Finding of Elements
 }

--- a/framework-tests/bellatrix.web.tests/src/test/java/controls/shadowdom/ShadowDomTests.java
+++ b/framework-tests/bellatrix.web.tests/src/test/java/controls/shadowdom/ShadowDomTests.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NoSuchElementException;
+import org.testng.asserts.Assertion;
 import solutions.bellatrix.core.configuration.ConfigurationService;
 import solutions.bellatrix.web.components.Anchor;
 import solutions.bellatrix.web.components.Div;
@@ -12,6 +13,7 @@ import solutions.bellatrix.web.components.Select;
 import solutions.bellatrix.web.components.advanced.grid.Grid;
 import solutions.bellatrix.web.components.advanced.grid.GridCell;
 import solutions.bellatrix.web.components.shadowdom.ShadowRoot;
+import solutions.bellatrix.web.configuration.WebSettings;
 import solutions.bellatrix.web.infrastructure.Browser;
 import solutions.bellatrix.web.infrastructure.ExecutionBrowser;
 import solutions.bellatrix.web.infrastructure.Lifecycle;
@@ -124,6 +126,38 @@ public class ShadowDomTests extends WebTest {
         Assertions.assertAll(
                 () -> Assertions.assertDoesNotThrow(() -> shadowRoot.createAllByXPath(Div.class, "//nonExistentElement")),
                 () -> Assertions.assertTrue(shadowRoot.createAllByXPath(Div.class, "//nonExistentElement").isEmpty())
+        );
+    }
+
+    @Test
+    public void waitedTimeout_when_tryingToFindNonExistentElement() {
+        var shadowHost = app().create().byId(Div.class, "complexShadowHost");
+        var shadowRoot = shadowHost.getShadowRoot();
+
+        long startTime = System.currentTimeMillis();
+        try {
+            shadowRoot.createByXPath(Div.class, "//nonExistentElement");
+        } catch (NoSuchElementException ignored) {
+            var elapsedTime = System.currentTimeMillis() - startTime;
+
+            Assertions.assertTrue(elapsedTime > ConfigurationService.get(WebSettings.class).getTimeoutSettings().getElementWaitTimeout()*1000);
+        }
+    }
+
+    @Test
+    public void returnedEmptyListWithoutWaiting_when_tryingToFindNonExistentElements() {
+        var shadowHost = app().create().byId(Div.class, "complexShadowHost");
+        var shadowRoot = shadowHost.getShadowRoot();
+
+        long startTime = System.currentTimeMillis();
+
+        var isEmpty = shadowRoot.createAllByXPath(Div.class, "//nonExistentElement").isEmpty();
+
+        var elapsedTime = System.currentTimeMillis() - startTime;
+
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(isEmpty),
+                () -> Assertions.assertTrue(elapsedTime < ConfigurationService.get(WebSettings.class).getTimeoutSettings().getElementWaitTimeout()*1000)
         );
     }
 

--- a/framework-tests/bellatrix.web.tests/src/test/java/controls/shadowdom/ShadowDomTests.java
+++ b/framework-tests/bellatrix.web.tests/src/test/java/controls/shadowdom/ShadowDomTests.java
@@ -4,6 +4,7 @@ import common.configuration.TestPagesSettings;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.NoSuchElementException;
 import solutions.bellatrix.core.configuration.ConfigurationService;
 import solutions.bellatrix.web.components.Anchor;
 import solutions.bellatrix.web.components.Div;
@@ -112,7 +113,7 @@ public class ShadowDomTests extends WebTest {
         var shadowHost = app().create().byId(Div.class, "complexShadowHost");
         var shadowRoot = shadowHost.getShadowRoot();
 
-        Assertions.assertThrows(IllegalArgumentException.class, () -> shadowRoot.createByXPath(Div.class, "//nonExistentElement"));
+        Assertions.assertThrows(NoSuchElementException.class, () -> shadowRoot.createByXPath(Div.class, "//nonExistentElement"));
     }
 
     @Test


### PR DESCRIPTION
- [x] due to recent changes, `getHtml` stopped returning the actual shadow dom html in case the current element is `ShadowRoot`; fixed
- [x] retry logic for `createAll` (searching for multiple elements) was moved to `create` (searching for only one element), as it is a valid case to return a list of 0 elements. Furthermore retrying for a specified time and throwing an exception after that if no element was found is valid for `create`